### PR TITLE
refactor: 同步instances到kong的中，upstreamName可以由配置指定

### DIFF
--- a/polaris-sync-core/src/main/java/cn/polarismesh/polaris/sync/core/tasks/AbstractTaskEngine.java
+++ b/polaris-sync-core/src/main/java/cn/polarismesh/polaris/sync/core/tasks/AbstractTaskEngine.java
@@ -171,6 +171,12 @@ public abstract class AbstractTaskEngine<C extends ResourceCenter, T extends Syn
 		NamedResourceCenter<C> source = resourceSet.getSource();
 		NamedResourceCenter<C> dest = resourceSet.getDest();
 		Runnable pull = buildPullTask(source, dest, task.getMatchList());
+
+		if (resourceSet.getSource().getCenter().getType() == ResourceType.KUBERNETES
+				&& intervalMilli > DefaultValues.DEFAULT_INTERVAL_MS) {
+			// 目前kubernetes还没实现watch的模式，因此 pull 的时间要尽可能短
+			intervalMilli =  DefaultValues.DEFAULT_INTERVAL_MS;
+		}
 		ScheduledFuture<?> future = pullExecutor
 				.scheduleWithFixedDelay(pull, 0, intervalMilli, TimeUnit.MILLISECONDS);
 		pulledTasks.put(task.getName(), future);

--- a/polaris-sync-protobuf/src/main/proto/model.proto
+++ b/polaris-sync-protobuf/src/main/proto/model.proto
@@ -55,4 +55,7 @@ message Group {
   string name = 1;
 
   map<string, string> metadata = 2;
+
+  string upstreamName = 3; // 用于指定kong的upstream名字
+
 }

--- a/polaris-sync-registry-plugins/registry-kong/src/main/java/cn/polarismesh/polaris/sync/registry/plugins/kong/KongRegistryCenter.java
+++ b/polaris-sync-registry-plugins/registry-kong/src/main/java/cn/polarismesh/polaris/sync/registry/plugins/kong/KongRegistryCenter.java
@@ -22,6 +22,7 @@ import static cn.polarismesh.polaris.sync.common.rest.RestOperator.pickAddress;
 import cn.polarismesh.polaris.sync.common.rest.RestOperator;
 import cn.polarismesh.polaris.sync.common.rest.RestResponse;
 import cn.polarismesh.polaris.sync.common.rest.RestUtils;
+import cn.polarismesh.polaris.sync.common.utils.DefaultValues;
 import cn.polarismesh.polaris.sync.extension.ResourceEndpoint;
 import cn.polarismesh.polaris.sync.extension.ResourceType;
 import cn.polarismesh.polaris.sync.extension.registry.AbstractRegistryCenter;
@@ -145,56 +146,56 @@ public class KongRegistryCenter extends AbstractRegistryCenter {
 
     @Override
     public void updateServices(Collection<Service> services) {
-        ResourceEndpoint endpoint = registryInitRequest.getResourceEndpoint();
-        String address = pickAddress(endpoint.getServerAddresses());
-        //query all services in the source
-        List<ServiceObject> serviceObjects = new ArrayList<>();
-        if (!resolveAllServices(address, "", serviceObjects)) {
-            LOG.error("[Kong] fail to query all services, registry {}, address {}", endpoint, address);
-            return;
-        }
-        ServiceObjectList serviceObjectList = new ServiceObjectList();
-        serviceObjectList.setData(serviceObjects);
-        String sourceName = registryInitRequest.getSourceName();
-        ResourceType sourceType = registryInitRequest.getSourceType();
-        Map<Service, ServiceObject> serviceObjectMap = ConversionUtils.parseServiceObjects(serviceObjectList,
-                sourceName);
-        Set<ServiceObject> servicesToCreate = new HashSet<>();
-        Set<ServiceObject> servicesToDelete = new HashSet<>();
-        Set<Service> processedServices = new HashSet<>();
-        for (Service service : services) {
-            ServiceObject targetObject = serviceObjectMap.get(service);
-            if (null == targetObject) {
-                //new add target
-                servicesToCreate.add(ConversionUtils.serviceToServiceObject(service, sourceName, sourceType));
-            }
-            processedServices.add(service);
-        }
-        for (Map.Entry<Service, ServiceObject> entry : serviceObjectMap.entrySet()) {
-            if (!processedServices.contains(entry.getKey())) {
-                servicesToDelete.add(entry.getValue());
-            }
-        }
-        // process operation
-        int serviceAddCount = 0;
-        int serviceDeleteCount = 0;
-        if (!servicesToCreate.isEmpty()) {
-            LOG.info("[Kong] services(source {}) pending to create are {}", sourceName, servicesToCreate);
-            String servicesUrl = KongEndpointUtils.toServicesUrl(address);
-            for (ServiceObject serviceObject : servicesToCreate) {
-                processServiceRequest(servicesUrl, HttpMethod.POST, serviceObject, "create");
-                serviceAddCount++;
-            }
-        }
-        if (!servicesToDelete.isEmpty()) {
-            LOG.info("[Kong] services(source {})  pending to delete are {}", sourceName, servicesToDelete);
-            for (ServiceObject serviceObject : servicesToDelete) {
-                String serviceUrl = KongEndpointUtils.toServiceUrl(endpoint.getServerAddresses(), serviceObject.getName());
-                processServiceRequest(serviceUrl, HttpMethod.DELETE, null, "delete");
-                serviceDeleteCount++;
-            }
-        }
-        LOG.info("[Kong] success to update services(source {}), add {}, delete {}", sourceName, serviceAddCount, serviceDeleteCount);
+//        ResourceEndpoint endpoint = registryInitRequest.getResourceEndpoint();
+//        String address = pickAddress(endpoint.getServerAddresses());
+//        //query all services in the source
+//        List<ServiceObject> serviceObjects = new ArrayList<>();
+//        if (!resolveAllServices(address, "", serviceObjects)) {
+//            LOG.error("[Kong] fail to query all services, registry {}, address {}", endpoint, address);
+//            return;
+//        }
+//        ServiceObjectList serviceObjectList = new ServiceObjectList();
+//        serviceObjectList.setData(serviceObjects);
+//        String sourceName = registryInitRequest.getSourceName();
+//        ResourceType sourceType = registryInitRequest.getSourceType();
+//        Map<Service, ServiceObject> serviceObjectMap = ConversionUtils.parseServiceObjects(serviceObjectList,
+//                sourceName);
+//        Set<ServiceObject> servicesToCreate = new HashSet<>();
+//        Set<ServiceObject> servicesToDelete = new HashSet<>();
+//        Set<Service> processedServices = new HashSet<>();
+//        for (Service service : services) {
+//            ServiceObject targetObject = serviceObjectMap.get(service);
+//            if (null == targetObject) {
+//                //new add target
+//                servicesToCreate.add(ConversionUtils.serviceToServiceObject(service, sourceName, sourceType));
+//            }
+//            processedServices.add(service);
+//        }
+//        for (Map.Entry<Service, ServiceObject> entry : serviceObjectMap.entrySet()) {
+//            if (!processedServices.contains(entry.getKey())) {
+//                servicesToDelete.add(entry.getValue());
+//            }
+//        }
+//        // process operation
+//        int serviceAddCount = 0;
+//        int serviceDeleteCount = 0;
+//        if (!servicesToCreate.isEmpty()) {
+//            LOG.info("[Kong] services(source {}) pending to create are {}", sourceName, servicesToCreate);
+//            String servicesUrl = KongEndpointUtils.toServicesUrl(address);
+//            for (ServiceObject serviceObject : servicesToCreate) {
+//                processServiceRequest(servicesUrl, HttpMethod.POST, serviceObject, "create");
+//                serviceAddCount++;
+//            }
+//        }
+//        if (!servicesToDelete.isEmpty()) {
+//            LOG.info("[Kong] services(source {})  pending to delete are {}", sourceName, servicesToDelete);
+//            for (ServiceObject serviceObject : servicesToDelete) {
+//                String serviceUrl = KongEndpointUtils.toServiceUrl(endpoint.getServerAddresses(), serviceObject.getName());
+//                processServiceRequest(serviceUrl, HttpMethod.DELETE, null, "delete");
+//                serviceDeleteCount++;
+//            }
+//        }
+//        LOG.info("[Kong] success to update services(source {}), add {}, delete {}", sourceName, serviceAddCount, serviceDeleteCount);
     }
 
     private static final String SCHEME = "http://";
@@ -250,70 +251,125 @@ public class KongRegistryCenter extends AbstractRegistryCenter {
 
     @Override
     public void updateGroups(Service service, Collection<ModelProto.Group> groups) {
-        List<String> addressesList = registryInitRequest.getResourceEndpoint().getServerAddresses();
-        String address = pickAddress(addressesList);
-        //query all upstreams in the source
-        List<UpstreamObject> upstreams = new ArrayList<>();
-        if (!resolveAllUpstreams(address, "", upstreams)) {
-            LOG.error("[Kong] fail to query all upstreams for service {}, address {}", service, address);
-            return;
-        }
-        UpstreamObjectList upstreamObjectList = new UpstreamObjectList();
-        upstreamObjectList.setData(upstreams);
-        String sourceName = registryInitRequest.getSourceName();
-        ResourceType sourceType = registryInitRequest.getSourceType();
-        Map<String, UpstreamObject> upstreamObjectMap =
-                ConversionUtils.parseUpstreamObjects(upstreamObjectList, service, sourceName);
-        Set<UpstreamObject> upstreamsToCreate = new HashSet<>();
-        Set<UpstreamObject> upstreamsToDelete = new HashSet<>();
-        Set<String> processedGroups = new HashSet<>();
-        for (ModelProto.Group group : groups) {
-            UpstreamObject upstreamObject = upstreamObjectMap.get(group.getName());
-            if (null == upstreamObject) {
-                //new add target
-                upstreamsToCreate.add(
-                        ConversionUtils.groupToUpstreamObject(group.getName(), service, sourceName, sourceType));
-            }
-            processedGroups.add(group.getName());
-        }
-        for (Map.Entry<String, UpstreamObject> entry : upstreamObjectMap.entrySet()) {
-            if (!processedGroups.contains(entry.getKey())) {
-                upstreamsToDelete.add(entry.getValue());
-            }
-        }
-        // process operation
-        int upstreamAddCount = 0;
-        int upstreamDeleteCount = 0;
-        if (!upstreamsToCreate.isEmpty()) {
-            LOG.info("[Kong] upstreams(source {}) pending to create are {}", sourceName, upstreamsToCreate);
-            String upstreamsUrl = KongEndpointUtils.toUpstreamsUrl(address);
-            for (UpstreamObject upstreamObject : upstreamsToCreate) {
-                processUpstreamRequest(upstreamsUrl, HttpMethod.POST, upstreamObject, "create");
-                upstreamAddCount++;
-            }
-        }
-        if (!upstreamsToDelete.isEmpty()) {
-            LOG.info("[Kong] upstreams(source {}) pending to delete are {}", sourceName, upstreamsToDelete);
-            for (UpstreamObject upstreamObject : upstreamsToDelete) {
-                String upstreamUrl = KongEndpointUtils.toUpstreamUrl(addressesList, upstreamObject.getName());
-                processUpstreamRequest(upstreamUrl, HttpMethod.DELETE, null, "delete");
-                upstreamDeleteCount++;
-            }
-        }
-        LOG.info("[Kong] success to update upstreams(source {}) for service {}, add {}, delete {}",
-                sourceName, service,  upstreamAddCount, upstreamDeleteCount);
+//        List<String> addressesList = registryInitRequest.getResourceEndpoint().getServerAddresses();
+//        String address = pickAddress(addressesList);
+//        //query all upstreams in the source
+//        List<UpstreamObject> upstreams = new ArrayList<>();
+//        if (!resolveAllUpstreams(address, "", upstreams)) {
+//            LOG.error("[Kong] fail to query all upstreams for service {}, address {}", service, address);
+//            return;
+//        }
+//        UpstreamObjectList upstreamObjectList = new UpstreamObjectList();
+//        upstreamObjectList.setData(upstreams);
+//        String sourceName = registryInitRequest.getSourceName();
+//        ResourceType sourceType = registryInitRequest.getSourceType();
+//        Map<String, UpstreamObject> upstreamObjectMap =
+//                ConversionUtils.parseUpstreamObjects(upstreamObjectList, service, sourceName);
+//        Set<UpstreamObject> upstreamsToCreate = new HashSet<>();
+//        Set<UpstreamObject> upstreamsToDelete = new HashSet<>();
+//        Set<String> processedGroups = new HashSet<>();
+//        for (ModelProto.Group group : groups) {
+//            UpstreamObject upstreamObject = upstreamObjectMap.get(group.getName());
+//            if (null == upstreamObject) {
+//                //new add target
+//                upstreamsToCreate.add(
+//                        ConversionUtils.groupToUpstreamObject(group.getName(), service, sourceName, sourceType));
+//            }
+//            processedGroups.add(group.getName());
+//        }
+//        for (Map.Entry<String, UpstreamObject> entry : upstreamObjectMap.entrySet()) {
+//            if (!processedGroups.contains(entry.getKey())) {
+//                upstreamsToDelete.add(entry.getValue());
+//            }
+//        }
+//        // process operation
+//        int upstreamAddCount = 0;
+//        int upstreamDeleteCount = 0;
+//        if (!upstreamsToCreate.isEmpty()) {
+//            LOG.info("[Kong] upstreams(source {}) pending to create are {}", sourceName, upstreamsToCreate);
+//            String upstreamsUrl = KongEndpointUtils.toUpstreamsUrl(address);
+//            for (UpstreamObject upstreamObject : upstreamsToCreate) {
+//                processUpstreamRequest(upstreamsUrl, HttpMethod.POST, upstreamObject, "create");
+//                upstreamAddCount++;
+//            }
+//        }
+//        if (!upstreamsToDelete.isEmpty()) {
+//            LOG.info("[Kong] upstreams(source {}) pending to delete are {}", sourceName, upstreamsToDelete);
+//            for (UpstreamObject upstreamObject : upstreamsToDelete) {
+//                String upstreamUrl = KongEndpointUtils.toUpstreamUrl(addressesList, upstreamObject.getName());
+//                processUpstreamRequest(upstreamUrl, HttpMethod.DELETE, null, "delete");
+//                upstreamDeleteCount++;
+//            }
+//        }
+//        LOG.info("[Kong] success to update upstreams(source {}) for service {}, add {}, delete {}",
+//                sourceName, service,  upstreamAddCount, upstreamDeleteCount);
     }
 
     @Override
     public void updateInstances(Service service, ModelProto.Group group, Collection<Instance> instances) {
         String sourceName = registryInitRequest.getSourceName();
+        String sourceType =  registryInitRequest.getSourceType().toString();
+
         LOG.info("[Kong] instances to update instances(source {}) group {}, service {}, is {}, ",
                 sourceName, group.getName(), service, instances);
-        String upstreamName = ConversionUtils.getUpstreamName(service, group.getName(), sourceName);
+
+        String upstreamName = group.getUpstreamName();
+        // 兼容group中没有传upstreamName的旧配置
+        if (upstreamName.isEmpty()) {
+            upstreamName = ConversionUtils.getUpstreamName(service, group.getName(), sourceName);
+        }
+
         List<String> addressesList = registryInitRequest.getResourceEndpoint().getServerAddresses();
+
+        // 检查一下upstream，不存在，我们就不更新
+        String upstreamReadUrl = KongEndpointUtils.toUpstreamUrl(addressesList, upstreamName);
+        RestResponse<String> restResponse = restOperator.curlRemoteEndpoint(
+                upstreamReadUrl, HttpMethod.GET, RestUtils.getRequestEntity(token, null), String.class);
+
+        if (restResponse.hasServerError()) {
+            LOG.error("[Kong] server error to query upstream {}, reason {}",
+                    upstreamReadUrl, restResponse.getException().getMessage());
+            return;
+        }
+        if (restResponse.hasTextError()) {
+            LOG.warn("[Kong] text error to query targets {}, code {}, reason {}",
+                    upstreamReadUrl, restResponse.getRawStatusCode(), restResponse.getStatusText());
+            return;
+        }
+        if (restResponse.hasNormalResponse()) {
+            ResponseEntity<String> strEntity = restResponse.getResponseEntity();
+            UpstreamObject upstream = RestUtils.unmarshalJsonText(strEntity.getBody(), UpstreamObject.class);
+            if (null == upstream) {
+                LOG.error("[Kong] invalid response to query upstream {}, text {}",
+                        upstreamReadUrl, strEntity.getBody());
+                return;
+            }
+
+            // upstream配置的服务来源类型，是否与upstream一致，如果不一致，不需要执行下面的同步流程
+            boolean matchType = false;
+            if ( upstream.getTags() != null) {
+                for (String tag : upstream.getTags()) {
+                    if (tag.equalsIgnoreCase(sourceType)) {
+                        matchType = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!matchType) {
+                LOG.warn("[Kong] {} sourceType:{} is not the same as tag", upstreamName, sourceType);
+                return;
+            }
+
+        } else {
+            LOG.error("[Kong] invalid response to query upstream {}, has abnormal response", upstreamReadUrl);
+            return;
+        }
+
+
         String targetReadUrl = KongEndpointUtils.toTargetsReadUrl(addressesList, upstreamName);
 
-        RestResponse<String> restResponse = restOperator.curlRemoteEndpoint(
+        restResponse = restOperator.curlRemoteEndpoint(
                 targetReadUrl, HttpMethod.GET, RestUtils.getRequestEntity(token, null), String.class);
         processHealthCheck(restResponse);
         if (restResponse.hasServerError()) {

--- a/polaris-sync-server/src/main/resources/application.yml
+++ b/polaris-sync-server/src/main/resources/application.yml
@@ -15,7 +15,7 @@ polaris:
         namespace: ${POLARIS_SYNC_CONFIG_K8S_NAMESPACE:}
         configmapName: ${POLARIS_SYNC_CONFIG_K8S_CONFIGMAP_NAME:polaris-sync-config}
         dataId: ${POLARIS_SYNC_CONFIG_K8S_CONFIGMAP_DATA_ID:registry_watch.json}
-        watchFile: ${POLARIS_SYNC_REGISTRY_FILE_WATCH:conf/sync-config.json}
+        watchFile: ${POLARIS_SYNC_REGISTRY_FILE_WATCH:conf/sync-registry.json}
     config:
       configProvider: ${POLARIS_SYNC_CONFIGCENTER_CONFIG_PROVIDER:file}
       configBackupPath: ${POLARIS_SYNC_CONFIG_BACKUP_PATH:conf/config/sync-config-backup.json}

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     </scm>
 
     <properties>
-        <revision>0.3.0-beta</revision>
+        <revision>0.4.0-beta</revision>
         <timestamp>${maven.build.timestamp}</timestamp>
         <kubernetes.client.version>15.0.1</kubernetes.client.version>
         <!-- Spring Cloud -->


### PR DESCRIPTION
1. 同步instances到kong的中，upstreamName可以由配置指定
2. 同步组件同步节点列表到Kong的upstream时候，检查服务的后端类型，类型不匹配，不同步节点，用来避免后端类型修改后，但同步组件配置还没修改，导致节点同步出错
3. 不再主动创建kong的service和upstream，也不维护service和upstream的生命周期
