### PR TITLE
添加 ZooKeeper 与 Polaris 之间同步dubbo服务的功能

### DIFF
--- a/polaris-sync-core/src/main/java/cn/polarismesh/polaris/sync/core/tasks/AbstractTaskEngine.java
+++ b/polaris-sync-core/src/main/java/cn/polarismesh/polaris/sync/core/tasks/AbstractTaskEngine.java
@@ -17,20 +17,6 @@
 
 package cn.polarismesh.polaris.sync.core.tasks;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
 import cn.polarismesh.polaris.sync.common.pool.NamedThreadFactory;
 import cn.polarismesh.polaris.sync.common.utils.DefaultValues;
 import cn.polarismesh.polaris.sync.core.utils.CommonUtils;
@@ -44,8 +30,10 @@ import cn.polarismesh.polaris.sync.model.pb.ModelProto;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.util.CollectionUtils;
+
+import java.util.*;
+import java.util.concurrent.*;
 
 /**
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
@@ -74,7 +62,12 @@ public abstract class AbstractTaskEngine<C extends ResourceCenter, T extends Syn
 
 	private final Map<String, ResourceSet<C>> resources = new HashMap<>();
 
-	protected final Map<ResourceType, Class<? extends ResourceCenter>> typeClassMap = new HashMap<>();
+	protected final Map<ResourceType, Class<? extends ResourceCenter>> typeClassMap = new HashMap<ResourceType, Class<? extends ResourceCenter>>() {
+		@Override
+		public Class<? extends ResourceCenter> put(ResourceType key, Class<? extends ResourceCenter> value) {
+			return super.put(key, value);
+		}
+	};
 
 	private final Object configLock = new Object();
 

--- a/polaris-sync-core/src/main/java/cn/polarismesh/polaris/sync/core/tasks/registry/AbstractTask.java
+++ b/polaris-sync-core/src/main/java/cn/polarismesh/polaris/sync/core/tasks/registry/AbstractTask.java
@@ -17,11 +17,14 @@
 
 package cn.polarismesh.polaris.sync.core.tasks.registry;
 
-import java.util.Objects;
-
 import cn.polarismesh.polaris.sync.common.utils.DefaultValues;
 import cn.polarismesh.polaris.sync.extension.ResourceType;
 import cn.polarismesh.polaris.sync.extension.registry.Service;
+import com.tencent.polaris.client.pb.ServiceProto;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
@@ -57,6 +60,20 @@ public interface AbstractTask extends Runnable {
 		}
 
 		return service;
+	}
+
+	List<ServiceProto.Service> getAllServices(String namespace);
+
+
+	default boolean tryProcessWildcardService(Service allServiceTag, Consumer<Service> consumer) {
+		if (!"*".equals(allServiceTag.getService())) {
+			return false;
+		}
+		String namespace = allServiceTag.getNamespace();
+		List<ServiceProto.Service> allServices = getAllServices(namespace);
+		allServices.stream().map(s -> new Service(namespace, s.getName().getValue()))
+				.forEach(consumer);
+		return true;
 	}
 
 }

--- a/polaris-sync-core/src/main/java/cn/polarismesh/polaris/sync/core/tasks/registry/RegistrySyncTask.java
+++ b/polaris-sync-core/src/main/java/cn/polarismesh/polaris/sync/core/tasks/registry/RegistrySyncTask.java
@@ -17,15 +17,14 @@
 
 package cn.polarismesh.polaris.sync.core.tasks.registry;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
-
 import cn.polarismesh.polaris.sync.core.tasks.SyncTask;
 import cn.polarismesh.polaris.sync.extension.Authorization;
 import cn.polarismesh.polaris.sync.extension.ResourceEndpoint;
 import cn.polarismesh.polaris.sync.extension.ResourceType;
 import cn.polarismesh.polaris.sync.registry.pb.RegistryProto;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
@@ -89,6 +88,9 @@ public class RegistrySyncTask implements SyncTask {
 		if (RegistryProto.RegistryEndpoint.RegistryType.kubernetes.equals(t)) {
 			return ResourceType.KUBERNETES;
 		}
+		if (RegistryProto.RegistryEndpoint.RegistryType.zookeeper.equals(t)) {
+			return ResourceType.ZOOKEEPER;
+		}
 		
 		return ResourceType.UNKNOWN;
 	}
@@ -96,6 +98,7 @@ public class RegistrySyncTask implements SyncTask {
 	private static ResourceEndpoint parse(RegistryProto.RegistryEndpoint endpoint) {
 		ResourceEndpoint source = ResourceEndpoint.builder()
 				.addresses(endpoint.getAddressesList())
+				.options(endpoint.getOptionsMap())
 				.name(endpoint.getName())
 				.productName(endpoint.getProductName())
 				.resourceType(find(endpoint.getType()))

--- a/polaris-sync-extension/src/main/java/cn/polarismesh/polaris/sync/extension/ResourceEndpoint.java
+++ b/polaris-sync-extension/src/main/java/cn/polarismesh/polaris/sync/extension/ResourceEndpoint.java
@@ -1,6 +1,7 @@
 package cn.polarismesh.polaris.sync.extension;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
@@ -18,6 +19,8 @@ public class ResourceEndpoint {
 	private Authorization authorization;
 
 	private Database database;
+
+	private Map<String, String> options;
 
 
 	public String getName() {
@@ -44,6 +47,10 @@ public class ResourceEndpoint {
 		return database;
 	}
 
+	public Map<String, String> getOptions() {
+		return options;
+	}
+
 	public static ResourceEndpointBuilder builder() {
 		return new ResourceEndpointBuilder();
 	}
@@ -56,6 +63,8 @@ public class ResourceEndpoint {
 		private List<String> addresses;
 		private Authorization authorization;
 		private Database database;
+
+		private Map<String, String> options;
 
 		private ResourceEndpointBuilder() {
 		}
@@ -90,6 +99,11 @@ public class ResourceEndpoint {
 			return this;
 		}
 
+		public ResourceEndpointBuilder options(Map<String, String> options) {
+			this.options = options;
+			return this;
+		}
+
 		public ResourceEndpoint build() {
 			ResourceEndpoint resourceEndpoint = new ResourceEndpoint();
 			resourceEndpoint.addresses = this.addresses;
@@ -98,6 +112,7 @@ public class ResourceEndpoint {
 			resourceEndpoint.authorization = this.authorization;
 			resourceEndpoint.database = this.database;
 			resourceEndpoint.productName = this.productName;
+			resourceEndpoint.options = this.options;
 			return resourceEndpoint;
 		}
 	}

--- a/polaris-sync-extension/src/main/java/cn/polarismesh/polaris/sync/extension/ResourceType.java
+++ b/polaris-sync-extension/src/main/java/cn/polarismesh/polaris/sync/extension/ResourceType.java
@@ -17,7 +17,9 @@ public enum ResourceType {
 
 	KUBERNETES("kubernetes"),
 
-	APOLLO("apollo")
+	APOLLO("apollo"),
+
+	ZOOKEEPER("zookeeper"),
 	;
 
 	private final String name;

--- a/polaris-sync-extension/src/main/java/cn/polarismesh/polaris/sync/extension/registry/AbstractRegistryCenter.java
+++ b/polaris-sync-extension/src/main/java/cn/polarismesh/polaris/sync/extension/registry/AbstractRegistryCenter.java
@@ -22,10 +22,24 @@ import cn.polarismesh.polaris.sync.extension.utils.ResponseUtils;
 import cn.polarismesh.polaris.sync.extension.utils.StatusCodes;
 import com.tencent.polaris.client.pb.ResponseProto.DiscoverResponse;
 import com.tencent.polaris.client.pb.ResponseProto.DiscoverResponse.DiscoverResponseType;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class AbstractRegistryCenter implements RegistryCenter {
-
+    public static Map<String, Set<ServiceAlias>> ServiceAlias = new HashMap<String, Set<ServiceAlias>>() {
+        @Override
+        public Set<ServiceAlias> get(Object key) {
+            Set<ServiceAlias> aliases = super.get(key);
+            if (aliases == null) {
+                put(key.toString(), aliases = new HashSet<>());
+            }
+            return aliases;
+        }
+    };
 
     protected final AtomicInteger serverErrorCount = new AtomicInteger(0);
 

--- a/polaris-sync-extension/src/main/java/cn/polarismesh/polaris/sync/extension/registry/Service.java
+++ b/polaris-sync-extension/src/main/java/cn/polarismesh/polaris/sync/extension/registry/Service.java
@@ -17,13 +17,15 @@
 
 package cn.polarismesh.polaris.sync.extension.registry;
 
-import java.util.Objects;
+import java.util.*;
 
 public class Service {
 
     private final String namespace;
 
     private final String service;
+
+    private Map<String, String> metadata;
 
     public Service(String namespace, String service) {
         this.namespace = namespace;
@@ -36,6 +38,24 @@ public class Service {
 
     public String getService() {
         return service;
+    }
+
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    public void addMetadata(String k, String v) {
+        if (metadata == null) {
+            metadata = new LinkedHashMap<>();
+        }
+        metadata.put(k, v);
+    }
+
+    public void addMetadata(Map<String, String> metadata) {
+        if (this.metadata == null) {
+            this.metadata = new LinkedHashMap<>();
+        }
+        this.metadata.putAll(metadata);
     }
 
     @Override

--- a/polaris-sync-extension/src/main/java/cn/polarismesh/polaris/sync/extension/registry/ServiceAlias.java
+++ b/polaris-sync-extension/src/main/java/cn/polarismesh/polaris/sync/extension/registry/ServiceAlias.java
@@ -1,0 +1,50 @@
+package cn.polarismesh.polaris.sync.extension.registry;
+
+/**
+ * @author <a href="mailto:amyson99@foxmail.com">amyson</a>
+ */
+public class ServiceAlias {
+    private final String service;
+
+    private final String namespace;
+
+    private final String alias;
+    private final String alias_namespace; //used to generate json
+
+    public ServiceAlias(String service, String namespace, String alias) {
+        this.service = service;
+        this.namespace = namespace;
+        this.alias = alias;
+        this.alias_namespace = namespace;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public String getAlias_namespace() {
+        return alias_namespace;
+    }
+
+    @Override
+    public int hashCode() {
+        return namespace.hashCode() * 31 + alias.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof ServiceAlias) {
+            ServiceAlias sa = (ServiceAlias) obj;
+            return this.namespace.equals(sa.namespace) && this.alias.equals(sa.alias);
+        }
+        return false;
+    }
+}

--- a/polaris-sync-extension/src/main/java/cn/polarismesh/polaris/sync/extension/utils/ResponseUtils.java
+++ b/polaris-sync-extension/src/main/java/cn/polarismesh/polaris/sync/extension/utils/ResponseUtils.java
@@ -71,9 +71,13 @@ public class ResponseUtils {
     public static DiscoverResponse.Builder toDiscoverResponse(Service service, int code, DiscoverResponseType type) {
         Builder builder = DiscoverResponse.newBuilder();
         if (null != service) {
-            builder.setService(
-                    ServiceProto.Service.newBuilder().setName(toStringValue(service.getService()))
-                            .setNamespace(toStringValue(service.getNamespace())).build());
+            ServiceProto.Service.Builder svrBuilder = ServiceProto.Service.newBuilder()
+                    .setName(toStringValue(service.getService()))
+                    .setNamespace(toStringValue(service.getNamespace()));
+            if (service.getMetadata() != null) {
+                svrBuilder.putAllMetadata(service.getMetadata());
+            }
+            builder.setService(svrBuilder.build());
         }
         builder.setCode(toUInt32Value(code));
         builder.setType(type);

--- a/polaris-sync-protobuf/src/main/proto/registry.proto
+++ b/polaris-sync-protobuf/src/main/proto/registry.proto
@@ -43,6 +43,7 @@ message RegistryEndpoint {
     polaris = 3;
     kong = 4;
     kubernetes = 5;
+    zookeeper = 6;
   }
 
   RegistryType type = 2;
@@ -56,6 +57,8 @@ message RegistryEndpoint {
   string password = 6;
 
   string product_name = 7 [json_name = "product_name"];
+
+  map<string, string> options = 8;
 }
 
 message Match {

--- a/polaris-sync-registry-plugins/pom.xml
+++ b/polaris-sync-registry-plugins/pom.xml
@@ -17,6 +17,7 @@
         <module>registry-consul</module>
         <module>registry-polaris</module>
         <module>registry-kubernetes</module>
+        <module>registry-zookeeper</module>
     </modules>
     <packaging>pom</packaging>
     <description>Polaris Sync Plugins POM</description>

--- a/polaris-sync-registry-plugins/registry-polaris/src/main/java/cn/polarismesh/polaris/sync/registry/plugins/polaris/PolarisEndpointUtils.java
+++ b/polaris-sync-registry-plugins/registry-polaris/src/main/java/cn/polarismesh/polaris/sync/registry/plugins/polaris/PolarisEndpointUtils.java
@@ -17,11 +17,26 @@
 
 package cn.polarismesh.polaris.sync.registry.plugins.polaris;
 
-import static cn.polarismesh.polaris.sync.common.rest.RestOperator.pickAddress;
-
 import java.util.List;
 
+import static cn.polarismesh.polaris.sync.common.rest.RestOperator.pickAddress;
+
 public class PolarisEndpointUtils {
+
+    public static String toServicesUrl(List<String> addresses) {
+        String address = pickAddress(addresses);
+        return String.format("http://%s/naming/v1/services", address);
+    }
+
+    public static String toServicesDeleteUrl(List<String> addresses) {
+        String address = pickAddress(addresses);
+        return String.format("http://%s/naming/v1/services/delete", address);
+    }
+
+    public static String toServicesAliasUrl(List<String> addresses) {
+        String address = pickAddress(addresses);
+        return String.format("http://%s/naming/v1/service/alias", address);
+    }
 
     public static String toInstancesUrl(List<String> addresses) {
         String address = pickAddress(addresses);

--- a/polaris-sync-registry-plugins/registry-zookeeper/pom.xml
+++ b/polaris-sync-registry-plugins/registry-zookeeper/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>polaris-sync-registry-plugins</artifactId>
+        <groupId>com.tencent.polaris</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>registry-zookeeper</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>3.8.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.tencent.polaris</groupId>
+            <artifactId>polaris-sync-extension</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.tencent.polaris</groupId>
+            <artifactId>polaris-sync-commons</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/polaris-sync-registry-plugins/registry-zookeeper/src/main/java/cn/polarismesh/polaris/sync/registry/plugins/nacos/ZookeeperClient.java
+++ b/polaris-sync-registry-plugins/registry-zookeeper/src/main/java/cn/polarismesh/polaris/sync/registry/plugins/nacos/ZookeeperClient.java
@@ -1,0 +1,137 @@
+/*
+ * Tencent is pleased to support the open source community by making Polaris available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cn.polarismesh.polaris.sync.registry.plugins.nacos;
+
+import org.apache.zookeeper.*;
+import org.apache.zookeeper.server.DumbWatcher;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static cn.polarismesh.polaris.sync.registry.plugins.nacos.ZookeeperRegistryCenter.dealError;
+import static cn.polarismesh.polaris.sync.registry.plugins.nacos.ZookeeperRegistryCenter.halt;
+import static org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE;
+
+/**
+ * @author <a href="mailto:amyson99@foxmail.com">amyson</a>
+ */
+public class ZookeeperClient {
+    static byte[] empty = new byte[0];
+    private ZooKeeper zk;
+
+    public ZookeeperClient(String addr) {
+        zk = getZooKeeper(addr);
+    }
+
+    List<String> getChildren(String path) {
+        try {
+            return zk.getChildren(path, false);
+        } catch (Exception ex) {
+            if (ex instanceof KeeperException.NoNodeException) {
+                return Collections.emptyList();
+            }
+            dealError("fail to get children of path {}", path, ex);
+            return Collections.emptyList();
+        }
+    }
+
+    String getData(String path) {
+        try {
+            byte[] bs = zk.getData(path, false, null);
+            return new String(bs);
+        } catch (Exception ex) {
+            dealError("fail to get data of path {}", path, ex);
+            return null;
+        }
+    }
+
+    void createTempPath(String path) {
+        parentPaths(path).forEach(parent -> createPath(parent, CreateMode.PERSISTENT));
+        createPath(path, CreateMode.EPHEMERAL);
+    }
+
+    void createPath(String path, CreateMode mode) {
+        try {
+            zk.create(path, empty, OPEN_ACL_UNSAFE, mode);
+        } catch (Exception ex) {
+            if (!(ex instanceof KeeperException.NodeExistsException)) {
+                dealError("fail to create path {}", path, ex);
+            }
+        }
+    }
+
+    static List<String> parentPaths(String path) {
+        String[] paths = path.split("/");
+        List<String> pathAndParents = new ArrayList<>(paths.length);
+        for (int i = paths.length - 1; i > 1; i--) {
+            pathAndParents.add(join(i, paths));
+        }
+        Collections.reverse(pathAndParents);
+        return pathAndParents;
+    }
+
+    static String join(int limit, String... strings) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < limit; i++) {
+            sb.append(strings[i]).append("/");
+        }
+        return sb.substring(0, sb.length() - 1);
+    }
+
+    void deletePath(String path) {
+        try {
+            zk.delete(path, -1);
+        } catch (Exception ex) {
+            dealError("fail to delete path {}", path, ex);
+        }
+    }
+
+    void watch(String path, Watcher watcher) {
+        try {
+            zk.addWatch(path, watcher, AddWatchMode.PERSISTENT);
+        } catch (Exception ex) {
+            dealError("fail to watch path {}", path, ex);
+        }
+    }
+
+    void unWatch(String path, Watcher watcher) {
+        try {
+            zk.removeWatches(path, watcher, Watcher.WatcherType.Any, true);
+        } catch (Exception ex) {
+            dealError("fail to watch path {}", path, ex);
+        }
+    }
+
+    public void close() {
+        try {
+            zk.close(200);
+        } catch (InterruptedException ignored) {
+        }
+    }
+
+    private ZooKeeper getZooKeeper(String address) {
+        try {
+            return new ZooKeeper(address, 120000, new DumbWatcher());
+        } catch (IOException e) {
+            halt("connect to {} failed", address, e);
+            return null;
+        }
+    }
+}

--- a/polaris-sync-registry-plugins/registry-zookeeper/src/main/java/cn/polarismesh/polaris/sync/registry/plugins/nacos/ZookeeperRegistryCenter.java
+++ b/polaris-sync-registry-plugins/registry-zookeeper/src/main/java/cn/polarismesh/polaris/sync/registry/plugins/nacos/ZookeeperRegistryCenter.java
@@ -1,0 +1,263 @@
+/*
+ * Tencent is pleased to support the open source community by making Polaris available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cn.polarismesh.polaris.sync.registry.plugins.nacos;
+
+import cn.polarismesh.polaris.sync.common.utils.DefaultValues;
+import cn.polarismesh.polaris.sync.extension.ResourceEndpoint;
+import cn.polarismesh.polaris.sync.extension.ResourceType;
+import cn.polarismesh.polaris.sync.extension.registry.AbstractRegistryCenter;
+import cn.polarismesh.polaris.sync.extension.registry.RegistryInitRequest;
+import cn.polarismesh.polaris.sync.extension.registry.Service;
+import cn.polarismesh.polaris.sync.extension.registry.WatchEvent;
+import cn.polarismesh.polaris.sync.extension.utils.ResponseUtils;
+import cn.polarismesh.polaris.sync.extension.utils.StatusCodes;
+import cn.polarismesh.polaris.sync.model.pb.ModelProto;
+import cn.polarismesh.polaris.sync.registry.plugins.nacos.model.MicroService;
+import cn.polarismesh.polaris.sync.registry.plugins.nacos.model.MicroServiceInstance;
+import com.tencent.polaris.client.pb.ResponseProto.DiscoverResponse;
+import com.tencent.polaris.client.pb.ServiceProto;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static cn.polarismesh.polaris.sync.registry.plugins.nacos.ZookeeperRegistryUtils.*;
+import static cn.polarismesh.polaris.sync.registry.plugins.nacos.ZookeeperRegistryUtils.toProviderPath;
+import static org.apache.zookeeper.Watcher.Event.EventType.*;
+
+/**
+ * @author <a href="mailto:amyson99@foxmail.com">amyson</a>
+ */
+@Component
+public class ZookeeperRegistryCenter extends AbstractRegistryCenter {
+    /*key in options config, the value indicates the root path holds services.
+      when has much root path, splits by ","   */
+    public static final String OPTIONS_KEY_ZK_ROOT_PATH = "root_paths";
+
+    private static final Logger LOG = LoggerFactory.getLogger(ZookeeperRegistryCenter.class);
+    private static final Marker LOG_MARKER = MarkerFactory.getMarker("[ZooKeeper][Registry] ");
+
+    static ZookeeperClient zkClient;
+
+    private List<String> rootPaths;
+
+    //{application} -> DubboService
+    private Map<String, MicroService> microServices;
+
+
+    private Map<String, ZkWatcher> watchers = new HashMap<>();
+
+    public class ZkWatcher implements Watcher {
+        String path;
+        Service service;
+        ResponseListener syncListener;
+
+        public ZkWatcher(String path, Service service, ResponseListener syncListener) {
+            this.path = path;
+            this.service = service;
+            this.syncListener = syncListener;
+        }
+
+        @Override
+        public void process(WatchedEvent event) {
+            if (event.getType() == NodeChildrenChanged) {
+                try {
+                    MicroService ds = microServices.get(service.getService());
+                    Map<String, MicroServiceInstance> instances = dubboServiceInstances(event.getPath(), true);
+                    ds.resetInstances(instances.values());
+                    DiscoverResponse res = instancesToResponse(service, instances.values());
+                    syncListener.onEvent(new WatchEvent(res));
+                } finally {
+                    zkClient.watch(event.getPath(), this);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void init(RegistryInitRequest request) {
+        ResourceEndpoint endpoint = request.getResourceEndpoint();
+
+        List<String> serverAddresses = endpoint.getServerAddresses();
+        if (serverAddresses.isEmpty()) {
+            halt("server address is empty");
+        }
+        zkClient = new ZookeeperClient(toZookeeperAddr(serverAddresses));
+
+        String[] strRootPaths = endpoint.getOptions()
+                .getOrDefault(OPTIONS_KEY_ZK_ROOT_PATH, "/dubbo")
+                .split(",");
+        rootPaths = toRootPaths(strRootPaths);
+    }
+
+    @Override
+    public DiscoverResponse listNamespaces() {
+        return super.listNamespaces();
+    }
+
+    @Override
+    public DiscoverResponse listServices(String namespace) {
+        DiscoverResponse.Builder resBuilder = ResponseUtils.toDiscoverResponse(null,
+                StatusCodes.SUCCESS, DiscoverResponse.DiscoverResponseType.SERVICES);
+        if (microServices == null) {
+            for (String rootPath : rootPaths) {
+                boolean isDubbo = isDubboService(rootPath);
+                if (isDubbo) {
+                    addMicroService(allDubboServices(rootPath));
+                } else {
+                    //addMicroService(allMicroServices(rootPath));
+                }
+            }
+        }
+        if (microServices != null)
+            addMicroServiceToResponse(namespace, resBuilder, microServices);
+        return resBuilder.build();
+    }
+
+    void addMicroService(Map<String, MicroService> services) {
+        if (services == null || services.isEmpty())
+            return;
+        if (microServices == null) {
+            microServices = services;
+            return;
+        }
+        for (Map.Entry<String, MicroService> e : services.entrySet()) {
+            MicroService ms = microServices.get(e.getKey());
+            if (ms != null) {
+                //todo 聚合微服务信息。目前不会出现这种情况
+            } else {
+                microServices.put(e.getKey(), e.getValue());
+            }
+        }
+    }
+
+    @Override
+    public DiscoverResponse listInstances(Service service, ModelProto.Group group) {
+        DiscoverResponse.Builder builder = ResponseUtils.toDiscoverResponse(service, StatusCodes.SUCCESS,
+                DiscoverResponse.DiscoverResponseType.INSTANCE);
+        MicroService microService = microServices.get(service.getService());
+        List<ServiceProto.Instance> instances = microService.getInstances().stream()
+                .map(ds -> toProtoInstance(service, ds))
+                .collect(Collectors.toList());
+        builder.addAllInstances(instances);
+        return builder.build();
+    }
+
+    private DiscoverResponse instancesToResponse(Service service, Collection<MicroServiceInstance> instances) {
+        DiscoverResponse.Builder resBuilder = ResponseUtils.toDiscoverResponse(service, StatusCodes.SUCCESS,
+                DiscoverResponse.DiscoverResponseType.SERVICES);
+        MicroService ds = microServices.get(service.getService());
+        for (MicroServiceInstance instance : ds.getInstances()) {
+            resBuilder.addInstances(toProtoInstance(service, instance));
+        }
+        return resBuilder.build();
+    }
+
+    @Override
+    public boolean watch(Service service, ResponseListener eventListener) {
+        if (DefaultValues.MATCH_ALL.equals(service.getService())) {
+            listServices(DefaultValues.DEFAULT_POLARIS_NAMESPACE);
+        }
+        for (Map.Entry<String, MicroService> e : microServices.entrySet()) {
+            String inf = e.getValue().getInterfaces().iterator().next();
+            String path = String.format("/dubbo/%s/providers", inf);
+            ZkWatcher watcher = new ZkWatcher(path, new Service(service.getNamespace(), e.getKey()), eventListener);
+            watchers.put(service.getService(), watcher);
+            zkClient.watch(path, watcher); //watch only one provider path
+        }
+        return true;
+    }
+
+    @Override
+    public void unwatch(Service service) {
+        ZkWatcher watcher = watchers.remove(service.getService());
+        if (watcher != null) {
+            zkClient.unWatch(watcher.path, watcher);
+        }
+    }
+
+    @Override
+    public void updateServices(Collection<Service> services) {
+    }
+
+    @Override
+    public void updateGroups(Service service, Collection<ModelProto.Group> groups) {
+    }
+
+    @Override
+    public void updateInstances(Service service, ModelProto.Group group, Collection<ServiceProto.Instance> instances) {
+        String svr = service.getService();
+        Map<String, String> providersInZk = new HashMap<>();
+        for (Map.Entry<String, MicroServiceInstance> e : dubboServiceInstances(getPathOfProviders(svr), false).entrySet()) {
+            String key = String.format("%s:%s", e.getValue().getHost(), e.getValue().getPort());
+            providersInZk.put(key, e.getKey());
+        }
+        Map<String, String> providersNotified = new HashMap<>();
+        for (ServiceProto.Instance instance : instances) {
+            String key = String.format("%s:%s", instance.getHost().getValue(), instance.getPort().getValue());
+            String path = toProviderPath(instance);
+            if (path != null) {
+                providersNotified.put(key, path);
+            }
+        }
+        List<String> pathsToAdd = new ArrayList<>();
+        for (Map.Entry<String, String> e : providersNotified.entrySet()) {
+            String pathInZk = providersInZk.remove(e.getKey());
+            if (pathInZk == null) {
+                pathsToAdd.add(e.getValue());
+            }
+        }
+
+        for (String path : pathsToAdd) {
+            zkClient.createTempPath(path);
+        }
+        for (String path : providersInZk.values()) {
+            zkClient.deletePath(path);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return ResourceType.ZOOKEEPER.name();
+    }
+
+    @Override
+    public ResourceType getType() {
+        return ResourceType.ZOOKEEPER;
+    }
+
+    @Override
+    public void destroy() {
+        zkClient.close();
+    }
+
+
+    static void halt(String message, Object... args) {
+        dealError("halt by fatal error: " + message, args);
+        System.exit(1);
+    }
+    static void dealError(String message, Object... args) {
+        LOG.error(LOG_MARKER, message, args);
+    }
+}

--- a/polaris-sync-registry-plugins/registry-zookeeper/src/main/java/cn/polarismesh/polaris/sync/registry/plugins/nacos/ZookeeperRegistryUtils.java
+++ b/polaris-sync-registry-plugins/registry-zookeeper/src/main/java/cn/polarismesh/polaris/sync/registry/plugins/nacos/ZookeeperRegistryUtils.java
@@ -1,0 +1,203 @@
+package cn.polarismesh.polaris.sync.registry.plugins.nacos;
+
+import cn.polarismesh.polaris.sync.common.rest.RestUtils;
+import cn.polarismesh.polaris.sync.extension.registry.AbstractRegistryCenter;
+import cn.polarismesh.polaris.sync.extension.registry.Service;
+import cn.polarismesh.polaris.sync.extension.registry.ServiceAlias;
+import cn.polarismesh.polaris.sync.extension.utils.ResponseUtils;
+import cn.polarismesh.polaris.sync.registry.plugins.nacos.model.MicroService;
+import cn.polarismesh.polaris.sync.registry.plugins.nacos.model.MicroServiceInstance;
+import com.google.gson.Gson;
+import com.tencent.polaris.client.pb.ResponseProto;
+import com.tencent.polaris.client.pb.ServiceProto;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URLEncoder;
+import java.util.*;
+
+import static cn.polarismesh.polaris.sync.common.utils.DefaultValues.META_SYNC;
+import static cn.polarismesh.polaris.sync.registry.plugins.nacos.ZookeeperRegistryCenter.zkClient;
+
+/**
+ * @author <a href="mailto:amyson99@foxmail.com">amyson</a>
+ * @date 2023-07-06
+ */
+public class ZookeeperRegistryUtils {
+    static Gson gson = new Gson();
+
+    static String toZookeeperAddr(List<String> serverAddresses) {
+        StringBuilder hosts = new StringBuilder();
+        for (String addr : serverAddresses) {
+            hosts.append(addr).append(",");
+        }
+        return hosts.substring(0, hosts.length() - 1);
+    }
+
+    static List<String> toRootPaths(String... strRootPaths) {
+        List<String> ls = new ArrayList<>();
+        for (String strRootPath : strRootPaths) {
+            if ('/' != strRootPath.charAt(0)) {
+                strRootPath = "/" + strRootPath;
+            }
+            ls.add(strRootPath);
+        }
+        return ls;
+    }
+
+    static Set<String> ignoreSubPaths = new HashSet<>(Arrays.asList("metadata", "config"));
+    //all dubbo services under path: /dubbo/
+    static Map<String, MicroService> allDubboServices(String dubboRootPath) {
+        Map<String, MicroService> dubboServices = new HashMap<>();
+
+        List<String> interfaces = zkClient.getChildren(dubboRootPath);
+        for (String inf : interfaces) {
+            if (ignoreSubPaths.contains(inf)) {
+                continue;
+            }
+            for (MicroServiceInstance instance : dubboServiceInstances(getPathOfProviders(inf), false).values()) {
+                if (instance.getMetadata().containsKey(META_SYNC)) {
+                    continue;
+                }
+                String appName = instance.getMetadata().get("application");
+                if (appName != null) {
+                    MicroService ds = dubboServices.computeIfAbsent(appName, k -> {
+                        Map<String, String> svrMeta = new HashMap<>();
+                        return new MicroService(true, svrMeta);
+                    });
+                    ds.getInterfaces().add(inf);
+                    ds.getInstances().add(instance);
+                }
+            }
+        }
+
+        return dubboServices;
+    }
+
+
+    static Map<String, MicroServiceInstance> dubboServiceInstances(String pathOfProviders, boolean ignoreSynced) {
+        Map<String, MicroServiceInstance> instances = new HashMap<>();
+        List<String> providers = zkClient.getChildren(pathOfProviders);
+        for (String provider : providers) {
+            MicroServiceInstance instance = parseDubboInstance(provider);
+            boolean isSynced = instance.getMetadata().containsKey(META_SYNC);
+            if (!ignoreSynced || !isSynced) {
+                instances.put(String.format("%s/%s", pathOfProviders, provider), instance);
+            }
+        }
+        return instances;
+    }
+
+    static MicroServiceInstance parseDubboInstance(String dubboProvider) {
+        String url = RestUtils.urlDecode(dubboProvider);
+        UriComponents uri = UriComponentsBuilder.fromUriString(url).build();
+
+        Map<String, String> meta = new HashMap<>();
+        meta.put("host", uri.getHost());
+        meta.put("port", String.valueOf(uri.getPort()));
+        uri.getQueryParams().forEach((key, val) -> {
+            meta.put(key, val.get(0));
+        });
+
+        return new MicroServiceInstance(uri.getScheme(), meta);
+    }
+
+    static void addMicroServiceToResponse(String namespace, ResponseProto.DiscoverResponse.Builder resBuilder,
+                                          Map<String, MicroService> dubboServices) {
+        dubboServices.forEach((app, ds) -> {
+            ServiceProto.Service.Builder svrBuilder = ServiceProto.Service.newBuilder();
+            svrBuilder.setNamespace(ResponseUtils.toStringValue(namespace))
+                    .setName(ResponseUtils.toStringValue(app))
+                    .putAllMetadata(ds.getMetadata());
+
+            Set<ServiceAlias> aliases = AbstractRegistryCenter.ServiceAlias.get(app);
+            for (String inf : ds.getInterfaces()) {
+                aliases.add(new ServiceAlias(app, namespace, inf));
+            }
+
+            resBuilder.addServices(svrBuilder);
+        });
+    }
+
+    static Map<String, MicroService> allMicroServices(String zkPath) {//SpringCloud mode
+        Map<String, MicroService> microServices = new HashMap<>();
+
+        List<String> services = zkClient.getChildren(zkPath);
+        for (String svr : services) {
+            List<String> instances = zkClient.getChildren(String.format("%s/%s", zkPath, svr));
+            if (instances.isEmpty())
+                continue;
+            MicroService ms = new MicroService(false, new HashMap<>());
+            microServices.put(svr, ms);
+            for (String instance : instances) {
+                String data = zkClient.getData(String.format("%s/%s/%s", zkPath, svr, instance));
+                if (data == null)
+                    continue;
+                addMicroInstances(ms, gson.fromJson(data, HashMap.class));
+            }
+        }
+
+        return microServices;
+    }
+
+    private static void addMicroInstances(MicroService ms, Map<String, Object> json) {
+        String address = (String) json.get("address");
+        Number port = (Number) json.get("port");
+        Number sslPort = (Number) json.get("null");
+        int iPort = 0;
+        String protocol = "http";
+        if (sslPort != null) {
+            protocol = "https";
+            iPort = sslPort.intValue();
+        } else {
+            iPort = port.intValue();
+        }
+
+        Map<String, Object> payload = (Map) json.get("payload");
+        MicroServiceInstance msi = new MicroServiceInstance(protocol, address, iPort, (Map) payload.get("metadata"));
+        ms.getInstances().add(msi);
+    }
+
+    static ServiceProto.Instance toProtoInstance(Service service, MicroServiceInstance dsi) {
+        ServiceProto.Instance.Builder builder = ServiceProto.Instance.newBuilder();
+
+        builder.setNamespace(ResponseUtils.toStringValue(service.getNamespace()));
+        builder.setService(ResponseUtils.toStringValue(service.getService()));
+        builder.setProtocol(ResponseUtils.toStringValue(dsi.getProtocol()));
+        builder.setHost(ResponseUtils.toStringValue(dsi.getHost()));
+        builder.setPort(ResponseUtils.toUInt32Value(dsi.getPort()));
+        builder.setIsolate(ResponseUtils.toBooleanValue(false));
+        builder.setHealthy(ResponseUtils.toBooleanValue(true));
+        builder.putAllMetadata(dsi.getMetadata());
+
+        return builder.build();
+    }
+
+    static String getPathOfProviders(String inf) {
+        return String.format("/dubbo/%s/providers", inf);
+    }
+
+    static boolean isDubboService(String path) {
+        return path.contains("dubbo");
+    }
+
+    static Set<String> paramsIgnored = new HashSet<>(Arrays.asList("zone", "path", "region", "campus"));
+    static String toProviderPath(ServiceProto.Instance instance) {
+        String protocol = instance.getProtocol().getValue();
+        if (!"dubbo".equals(protocol))
+            return null;
+
+        String svr = instance.getService().getValue();
+        String host = instance.getHost().getValue();
+        int port = instance.getPort().getValue();
+
+        StringBuilder params = new StringBuilder(META_SYNC).append("=");
+        for (Map.Entry<String, String> e : instance.getMetadataMap().entrySet()) {
+            if (!paramsIgnored.contains(e.getKey())) {
+                params.append("&").append(e.getKey()).append("=").append(e.getValue());
+            }
+        }
+        String dubboUrl = String.format("dubbo://%s:%s/%s?%s", host, port, svr, params);
+        return String.format("/dubbo/%s/providers/%s", svr, URLEncoder.encode(dubboUrl));
+    }
+}

--- a/polaris-sync-registry-plugins/registry-zookeeper/src/main/java/cn/polarismesh/polaris/sync/registry/plugins/nacos/model/MicroService.java
+++ b/polaris-sync-registry-plugins/registry-zookeeper/src/main/java/cn/polarismesh/polaris/sync/registry/plugins/nacos/model/MicroService.java
@@ -1,0 +1,45 @@
+package cn.polarismesh.polaris.sync.registry.plugins.nacos.model;
+
+import java.util.*;
+
+/**
+* @author <a href="mailto:amyson99@foxmail.com">amyson</a>
+*/
+public class MicroService {
+    private Set<String> interfaces;
+
+    //dubbo service is whether registered as traditional dubbo mode
+    private boolean dubboMode;
+
+    private Map<String, String> metadata;
+
+    private Set<MicroServiceInstance> instances;
+
+    public MicroService(boolean dubboMode, Map<String, String> metadata) {
+        this.metadata = metadata;
+        this.interfaces = new HashSet<>();
+        this.instances = new HashSet<>();
+        this.dubboMode = dubboMode;
+    }
+
+    public Set<String> getInterfaces() {
+        return interfaces;
+    }
+
+    public boolean isDubboMode() {
+        return dubboMode;
+    }
+
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    public Set<MicroServiceInstance> getInstances() {
+        return instances;
+    }
+
+    public void resetInstances(Collection<MicroServiceInstance> instances) {
+        this.instances.clear();
+        this.instances.addAll(instances);
+    }
+}

--- a/polaris-sync-registry-plugins/registry-zookeeper/src/main/java/cn/polarismesh/polaris/sync/registry/plugins/nacos/model/MicroServiceInstance.java
+++ b/polaris-sync-registry-plugins/registry-zookeeper/src/main/java/cn/polarismesh/polaris/sync/registry/plugins/nacos/model/MicroServiceInstance.java
@@ -1,0 +1,60 @@
+package cn.polarismesh.polaris.sync.registry.plugins.nacos.model;
+
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:amyson99@foxmail.com">amyson</a>
+ */
+public class MicroServiceInstance {
+    private Map<String, String> metadata;
+
+    private String protocol;
+    private String host;
+
+    private int port;
+
+    public MicroServiceInstance(String protocol, Map<String, String> metadata) {
+        this.protocol = protocol;
+        metadata.remove("interface");
+        metadata.remove("methods");
+        this.metadata = metadata;
+        this.host = metadata.get("host");
+        this.port = Integer.parseInt(metadata.get("port"));
+    }
+
+    public MicroServiceInstance(String protocol, String host, int port, Map<String, String> metadata) {
+        this.host = host;
+        this.port = port;
+        this.metadata = metadata;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public int hashCode() {
+        return host.hashCode() * 31 + port;
+    }
+
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof MicroServiceInstance)) {
+            return false;
+        }
+        MicroServiceInstance ds = (MicroServiceInstance) obj;
+        return this.host.equals(ds.host) && this.port == ds.port;
+    }
+}

--- a/polaris-sync-registry-plugins/registry-zookeeper/src/test/java/cn/polarismesh/polaris/sync/registry/plugins/nacos/ZookeeperClientTest.java
+++ b/polaris-sync-registry-plugins/registry-zookeeper/src/test/java/cn/polarismesh/polaris/sync/registry/plugins/nacos/ZookeeperClientTest.java
@@ -1,0 +1,24 @@
+package cn.polarismesh.polaris.sync.registry.plugins.nacos;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static cn.polarismesh.polaris.sync.registry.plugins.nacos.ZookeeperClient.parentPaths;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author <a href="mailto:amyson99@foxmail.com">amyson</a>
+ * @date 2023-07-27
+ */
+class ZookeeperClientTest {
+
+    @Test
+    void testParentPaths() {
+        String path = "a/b/c/d";
+        List<String> leveledPaths = parentPaths(path);
+        assertEquals(2, leveledPaths.size());
+        assertEquals("a/b", leveledPaths.get(0));
+        assertEquals("a/b/c", leveledPaths.get(1));
+    }
+}

--- a/polaris-sync-registry-plugins/registry-zookeeper/src/test/java/cn/polarismesh/polaris/sync/registry/plugins/nacos/ZookeeperRegistryUtilsTest.java
+++ b/polaris-sync-registry-plugins/registry-zookeeper/src/test/java/cn/polarismesh/polaris/sync/registry/plugins/nacos/ZookeeperRegistryUtilsTest.java
@@ -1,0 +1,40 @@
+package cn.polarismesh.polaris.sync.registry.plugins.nacos;
+
+import cn.polarismesh.polaris.sync.common.rest.RestUtils;
+import cn.polarismesh.polaris.sync.registry.plugins.nacos.model.MicroService;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static cn.polarismesh.polaris.sync.registry.plugins.nacos.ZookeeperRegistryUtils.allDubboServices;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author <a href="mailto:amyson99@foxmail.com">amyson</a>
+ * @date 2023-07-07
+ */
+public class ZookeeperRegistryUtilsTest {
+
+    @BeforeClass
+    public static void init() {
+        String addr = System.getProperty("zk-addr");
+        if (addr != null) {
+            ZookeeperRegistryCenter.zkClient = new ZookeeperClient(addr);
+        }
+    }
+
+    @Test
+    public void testDubboService2Interfaces() {
+        Map<String, MicroService> serviceMap = allDubboServices("/dubbo");
+        assertTrue(serviceMap.size() > 0);
+    }
+
+    @Test
+    public void testTemp() {
+        String json = "{\"a\":12}";
+        Map map = RestUtils.unmarshalJsonText(json, HashMap.class);
+        System.out.println(map);
+    }
+}

--- a/polaris-sync-registry-plugins/registry-zookeeper/src/test/resources/logback.xml
+++ b/polaris-sync-registry-plugins/registry-zookeeper/src/test/resources/logback.xml
@@ -1,0 +1,1 @@
+<root level="info"/>

--- a/polaris-sync-server/pom.xml
+++ b/polaris-sync-server/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>registry-kubernetes</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.tencent.polaris</groupId>
+            <artifactId>registry-zookeeper</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!--    配置中心插件    -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     </scm>
 
     <properties>
-        <revision>0.4.0-beta</revision>
+        <revision>0.5.0-beta</revision>
         <timestamp>${maven.build.timestamp}</timestamp>
         <kubernetes.client.version>15.0.1</kubernetes.client.version>
         <!-- Spring Cloud -->


### PR DESCRIPTION
实现ZooKeeper、Polaris间dubbo服务元数据同步。

- ZooKeeper向Polaris同步dubbo服务元数据
- Polaris向ZooKeeper同步dubbo服务元数据
- 监听Polaris、ZooKeeper，服务实例上下线时实时通知
- ZooKeeper中注册的接口服务，同步到Polaris时把 {application} 注册为服务、把接口注册为{application}服务的别称
